### PR TITLE
tsconfig @cloudflare/workers-types/2023-07-01

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
       "ESNext"
     ],
     "types": [
-      "@cloudflare/workers-types"
+      "@cloudflare/workers-types/2023-07-01"
     ],
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx"


### PR DESCRIPTION
Fixes typescript error due to missing worker API features in @cloudflare/worker-types e.g.

> bucket.list( { include ...

https://developers.cloudflare.com/r2/api/workers/workers-api-reference/#r2listoptions

![Screenshot 2024-08-08 at 16 29 10](https://github.com/user-attachments/assets/99f3c892-22aa-43d8-b5b8-3a6799958f15)
